### PR TITLE
Add logout and deal sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # SpicyBeats Events
 
 This project is a simple PHP demo for submitting and voting on deals.
+Users can log in, submit deals and vote. The main page now includes a
+"Sort by" option for ordering deals by recent submissions, vote count
+or rating. A logout endpoint (`logout.php`) has been added as well.
 
 ## Setup
 

--- a/api/get_deals.php
+++ b/api/get_deals.php
@@ -9,6 +9,7 @@ try {
     $status = 'approved';
     $category = $_GET['category'] ?? null;
     $search = $_GET['search'] ?? null;
+    $sort = $_GET['sort'] ?? 'recent';
     $page = max(1, (int)($_GET['page'] ?? 1));
     $limit = 10;
     $offset = ($page - 1) * $limit;
@@ -37,7 +38,14 @@ try {
         $params[] = $searchTerm;
     }
 
-    $sql .= " GROUP BY d.id ORDER BY d.created_at DESC LIMIT $limit OFFSET $offset";
+    $orderBy = 'd.created_at DESC';
+    if ($sort === 'votes') {
+        $orderBy = 'votes DESC';
+    } elseif ($sort === 'rating') {
+        $orderBy = 'avg_rating DESC';
+    }
+
+    $sql .= " GROUP BY d.id ORDER BY $orderBy LIMIT $limit OFFSET $offset";
 
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);

--- a/bagit.js
+++ b/bagit.js
@@ -2,10 +2,12 @@ const dealsContainer = document.getElementById('deals-container');
 const categorySelect = document.getElementById('category-select');
 const searchInput = document.getElementById('search-input');
 const searchBtn = document.getElementById('search-btn');
+const sortSelect = document.getElementById('sort-select');
 const loadMoreBtn = document.getElementById('load-more');
 let currentPage = 1;
 let lastCategory = '';
 let lastSearch = '';
+let lastSort = 'recent';
 
 // Load categories into dropdown
 fetch('api/get_categories.php')
@@ -22,13 +24,19 @@ fetch('api/get_categories.php')
 categorySelect.addEventListener('change', () => {
   currentPage = 1;
   lastCategory = categorySelect.value;
-  loadDeals(lastCategory, lastSearch, true);
+  loadDeals(lastCategory, lastSearch, lastSort, true);
 });
 
 searchBtn.addEventListener('click', () => {
   currentPage = 1;
   lastSearch = searchInput.value;
-  loadDeals(lastCategory, lastSearch, true);
+  loadDeals(lastCategory, lastSearch, lastSort, true);
+});
+
+sortSelect.addEventListener('change', () => {
+  currentPage = 1;
+  lastSort = sortSelect.value;
+  loadDeals(lastCategory, lastSearch, lastSort, true);
 });
 
 function vote(dealId, type) {
@@ -54,13 +62,16 @@ function vote(dealId, type) {
   });
 }
 
-function loadDeals(category = '', search = '', reset = false) {
+function loadDeals(category = '', search = '', sort = 'recent', reset = false) {
   let url = `api/get_deals.php?page=${currentPage}`;
   if (category) {
     url += `&category=${encodeURIComponent(category)}`;
   }
   if (search) {
     url += `&search=${encodeURIComponent(search)}`;
+  }
+  if (sort) {
+    url += `&sort=${encodeURIComponent(sort)}`;
   }
 
   fetch(url)
@@ -98,12 +109,12 @@ function loadDeals(category = '', search = '', reset = false) {
 }
 loadMoreBtn.addEventListener('click', () => {
   currentPage++;
-  loadDeals(lastCategory, lastSearch);
+  loadDeals(lastCategory, lastSearch, lastSort);
 });
 
 function init() {
   currentPage = 1;
-  loadDeals();
+  loadDeals(lastCategory, lastSearch, lastSort);
 }
 
 init();

--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header><h1>Welcome to SpicyBeats</h1></header>
+  <header>
+    <h1>Welcome to SpicyBeats</h1>
+    <nav>
+      <a href="logout.php">Logout</a>
+    </nav>
+  </header>
 
   <div class="filter-bar">
     <label for="category-select">Category:</label>
@@ -19,6 +24,12 @@
     </select>
     <input type="text" id="search-input" placeholder="Search deals" />
     <button id="search-btn">Search</button>
+    <label for="sort-select">Sort by:</label>
+    <select id="sort-select">
+      <option value="recent">Recent</option>
+      <option value="votes">Votes</option>
+      <option value="rating">Rating</option>
+    </select>
   </div>
 
   <main>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit;
+?>


### PR DESCRIPTION
## Summary
- add a user logout endpoint
- allow sorting deals by recency, votes or rating
- expose sorting menu on the homepage
- document logout and sorting in README

## Testing
- `php -l logout.php`
- `php -l api/get_deals.php`
- `php -l login.php`
- `php -l signup.php`
- `php -l admin/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_6888bf3be800832c8e4d622828bbfaac